### PR TITLE
Fan art alignment

### DIFF
--- a/src/theme/sass/components/_widgets.scss
+++ b/src/theme/sass/components/_widgets.scss
@@ -1,4 +1,3 @@
-
 // loading
 .loading-box {
   font-size: 30px;
@@ -442,7 +441,6 @@ input[type="text"] {
   img {
     cursor: pointer;
     width: 100%;
-    margin-top: -6%;
     min-width: 400px;
   }
   &.full-size {


### PR DESCRIPTION
Remove top margin as the top of the fan art generally contains the faces and these were being cropped of the top.

Made a quick 1 line change to line 445 on the github site itself and its made edits at line 1 and 493 that are unrelated.
