### PR TITLE
Fixed relative url for jsonrpc endpoint

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -14,7 +14,7 @@ var app = {
 
   state: 'notconnected', // Not connected yet
 
-  jsonRpcUrl: '/jsonrpc', // JsonRPC endpoint
+  jsonRpcUrl: 'jsonrpc', // JsonRPC endpoint
 
   itemsPerPage: 60, // Our default pagination amount
 


### PR DESCRIPTION
Using '/jsonrpc' can cause problems if you have a proxy infront of xbmc and it already has a relative URL.

Simply removing the '/' form the front of the jsonrpc url will fix it (and does not break non-proxied access). 
The problem is if you already have a relative url (https://mydomain.com/xbmcbox), then /jsonrpc will try to hit https://mydomain.com/jsonrpc (gets 404). If you change it to 'jsonrpc', then it will work correctly and hit https://mydomain.com/xbmcbox/jsonrpc
