### PR TITLE
Fixed relative URL for images

### DIFF
--- a/src/js/helpers/image.js
+++ b/src/js/helpers/image.js
@@ -58,7 +58,7 @@ app.image = {
       return app.image.defaultImage(type);
     }
     // return image with correct path
-    return app.settings.get('basePath', '/') + 'image/' + encodeURIComponent(rawPath);
+    return 'image/' + encodeURIComponent(rawPath);
   },
 
 


### PR DESCRIPTION
Removed "baseUrl" for "image/" paths since it always returned '/' and will break if xbmc is behind a proxy that already has a relative url.
This was tested to work behind proxy and directly on lan
