### PR TITLE
Sytles.css fixes

### DIFF
--- a/dist/theme/css/styles.css
+++ b/dist/theme/css/styles.css
@@ -2564,8 +2564,8 @@ body.section-search #sidebar-first {
 @media (min-width: 800px) {
   #now-playing,
   #browser-now-playing {
-    right: 330px;
-    left: 260px;
+    margin-right: 330px;
+    margin-left: 260px;
   }
 }
 
@@ -2876,6 +2876,7 @@ body.partymode-on a.party-mode i {
 .xbmc-remote .direction {
   background: #262b2a;
   height: 155px;
+  margin-top: -12px;
   width: 75%;
   float: left;
   margin-right: -100%;
@@ -5377,8 +5378,8 @@ h1.video-title {
   body #footer #browser-now-playing,
   body #browser-player-footer #now-playing,
   body #browser-player-footer #browser-now-playing {
-    right: 430px;
-    left: 330px;
+    margin-right: 430px;
+    margin-left: 330px;
   }
   body #footer .progress-wrapper,
   body #browser-player-footer .progress-wrapper {

--- a/src/theme/sass/breakpoints/_small.scss
+++ b/src/theme/sass/breakpoints/_small.scss
@@ -70,8 +70,8 @@ body {
     }
     #now-playing,
     #browser-now-playing {
-      margin-right: $width-sidebar-second + 70;
-      margin-left: $width-sidebar-first;
+      right: $width-sidebar-second + 70;
+      left: $width-sidebar-first;
     }
     .progress-wrapper {
       left: $width-sidebar-first + $height-footer;

--- a/src/theme/sass/components/_player.scss
+++ b/src/theme/sass/components/_player.scss
@@ -210,8 +210,8 @@
     color: #ddd;
   }
   @include breakpoint($width-tablet){
-    margin-right: $width-sidebar-second-small + 70;
-    margin-left: $width-sidebar-second-small;
+    right: $width-sidebar-second-small + 70;
+    left: $width-sidebar-second-small;
   }
 }
 

--- a/src/theme/sass/components/_remote.scss
+++ b/src/theme/sass/components/_remote.scss
@@ -62,7 +62,6 @@ $dark-bg: #262b2a;
   .direction {
     background: $dark-bg;
     height: $pad-height + 10;
-    margin-top: -12px;
     @include grid-span(3,1,4,0);
     position: relative;
     z-index: 10;


### PR DESCRIPTION
Fixed remote pad from being above the main-controls container by 12px.
Fixed the title in the now playing box from being cut off in browsers other than crhome.
