### PR TITLE
Fixes: minor rebrand XBMC -> Kodi and other fixes

### DIFF
--- a/dist/addon.xml
+++ b/dist/addon.xml
@@ -10,8 +10,8 @@
   <extension
     point="xbmc.gui.webinterface"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en">A modern Web UI for your XBMC</summary>
-    <description lang="en">A modern Web UI for your XBMC. Browse your Music, Movies or TV Shows from the comfort of your own web browser.  You can play media via XBMC or stream it in your browser. Works best with Chrome but plays well with most modern browsers. For more, see github.com/jez500/chorus</description>
+    <summary lang="en">A modern Web UI for Kodi</summary>
+    <description lang="en">A modern Web UI for your kodi. Browse your Music, Movies or TV Shows from the comfort of your own web browser.  You can play media via XBMC or stream it in your browser. Works best with Chrome but plays well with most modern browsers. For more, see github.com/jez500/chorus</description>
     <platform>all</platform>
     <language>en</language>
     <source>https://github.com/jez500/chorus</source>

--- a/dist/chorus.js
+++ b/dist/chorus.js
@@ -15253,7 +15253,7 @@ $(document).ready(function(){
           key: 'album',
           omitwrapper: true,
           items: [
-            {url: '#', class: 'album-add-xbmc', title: 'Add to XBMC', callback: function(){
+            {url: '#', class: 'album-add-xbmc', title: 'Add to Kodi', callback: function(){
               app.playlists.playlistAddItems('xbmc', 'append', 'album', model.albumid);
             }},
             {url: '#', class: 'album-add-local', title: 'Play in browser', callback: function(){
@@ -15273,7 +15273,7 @@ $(document).ready(function(){
           key: 'artist',
           omitwrapper: true,
           items: [
-            {url: '#', class: 'artist-add-xbmc', title: 'Add to XBMC', callback: function(){
+            {url: '#', class: 'artist-add-xbmc', title: 'Add to Kodi', callback: function(){
               app.playlists.playlistAddItems('xbmc', 'append', 'artist', model.artistid);
             }},
             {url: '#', class: 'artist-add-local', title: 'Play in browser', callback: function(){
@@ -15310,7 +15310,7 @@ $(document).ready(function(){
             {url: '#', class: 'refresh-playlist', title: 'Refresh Playlist'},
             {url: '#', class: 'party-mode', title: 'Party Mode <i class="fa fa-check"></i>'},
             {class: 'dropdown-header', title: 'Audio'},
-            {url: '#', class: 'save-playlist', title: 'Save XBMC Playlist'},
+            {url: '#', class: 'save-playlist', title: 'Save Kodi Playlist'},
             {url: '#', class: 'new-custom-playlist', title: 'New Browser Playlist'}
           ]
         };
@@ -16434,7 +16434,7 @@ app.Router = Backbone.Router.extend({
     $('#content').html(app.cached.xbmcView.render().$el);
 
     // set title
-    app.ui.setTitle('XBMC', {addATag: '#xbmc/home'});
+    app.ui.setTitle('Kodi', {addATag: '#xbmc/home'});
 
     // set menu
     app.shellView.selectMenuItem('xbmc', 'no-sidebar');
@@ -19318,7 +19318,7 @@ app.keymap = {
 
 ;/**
  * Deal with notifications from xbmc using web sockets
- * http://wiki.xbmc.org/?title=JSON-RPC_API/v6#Notifications_2
+ * http://kodi.wiki/view/JSON-RPC_API/v6#Notifications_2
  *
  * NOTE: for this to work You need to "Allow programs on other systems to control XBMC"
  */
@@ -19513,7 +19513,7 @@ app.notifications = {
 
       // xbmc shutdown
       case 'System.OnQuit':
-        app.notification('XBMC has quit');
+        app.notification('Kodi has quit');
         break;
     }
 
@@ -19665,12 +19665,12 @@ app.playerState = {
       // 10 mins with no connection - increase throttle
       if(app.counts['503total'] > 30){
         throttle = 6;
-        app.notification('No connection to XBMC for 10mins! I\'ll check if it\'s there less often now ');
+        app.notification('No connection to Kodi for 10mins! I\'ll check if it\'s there less often now ');
       }
       // 30 mins with no connection - increase throttle ((20min * 60sec) / (6throttle * 5interval)) + 30previousThrottle = 40
       if(app.counts['503total'] > 70){
         throttle = 12;
-        app.notification('No connection to XBMC for 30mins! I\'m pretty sure it has gone walkabout');
+        app.notification('No connection to Kodi for 30mins! I\'m pretty sure it has gone walkabout');
       }
 
       // reset count to 0 if at throttle
@@ -19684,7 +19684,7 @@ app.playerState = {
         app.counts[503]++;
         app.state = 'notconnected';
         if(app.counts[503] == 3){
-          app.notification('Lost connection to XBMC');
+          app.notification('Lost connection to Kodi');
         }
         return;
       } else {
@@ -21653,7 +21653,7 @@ app.xbmcController.command = function(command, options, callback, errorCallback)
 
 /**
  * Call an input command
- * http://wiki.xbmc.org/?title=JSON-RPC_API/v6#Input
+ * http://kodi.wiki/view/JSON-RPC_API/v6#Input
  *
  * @param type
  * @param callback
@@ -27079,7 +27079,7 @@ app.PvrChannelListItem = Backbone.View.extend({
       key: 'powerDown',
       omitwrapper: true,
       items: [
-        {url: '#', class: 'xbmc-quit', title: 'Quit XBMC', callback: function(){
+        {url: '#', class: 'xbmc-quit', title: 'Quit Kodi', callback: function(){
           // Quit xbmc
           app.xbmcController.command('Application.Quit');
         }},
@@ -29057,7 +29057,7 @@ app.XbmcChorusChangeLog = Backbone.View.extend({
       // render
       self.$el.html(app.nl2br(data));
       // set title
-      app.ui.setTitle('<a href="#xbmc/home">XBMC</a>Chorus ChangeLog');
+      app.ui.setTitle('<a href="#xbmc/home">Kodi</a>Chorus ChangeLog');
     });
 
     return this;
@@ -29092,7 +29092,7 @@ app.XbmcJSONrpcView = Backbone.View.extend({
   render:function () {
 
     // set title
-    app.ui.setTitle('<a href="#xbmc/home">XBMC</a>jsonRPC');
+    app.ui.setTitle('<a href="#xbmc/home">Kodi</a>jsonRPC');
 
     this.$el.empty();
 

--- a/dist/tpl/About.html
+++ b/dist/tpl/About.html
@@ -1,6 +1,6 @@
 <h2><a href="https://github.com/jez500/chorus" target="_blank" title="Get the source!"><%= name %></a></h2>
 <em>Version <span><%= version %></span></em>
-<p>Chorus is a slick web interface focused on using xbmc as a shared player.</p>
+<p>Chorus is a slick web interface focused on using Kodi as a shared player.</p>
 <br />
 <p>Created by Jeremy @ <a href="https://github.com/jez500" target="_blank">github.com/jez500</a></p>
 <p>Do you like Chorus?

--- a/dist/tpl/MovieView.html
+++ b/dist/tpl/MovieView.html
@@ -120,7 +120,7 @@
                     <div class="col-1">
                         <h2>HTML5 player</h2>
                         <p>Codec support is very <a href="https://developer.mozilla.org/en-US/docs/HTML/Supported_media_formats" target="_blank">limited in the browser</a>.
-                            H.264 video generally works but only with 2 channel audio. Works best in Chrome, may crash browser and/or XBMC!</p>
+                            H.264 video generally works but only with 2 channel audio. Works best in Chrome, may crash browser and/or Kodi!</p>
                         <div class="buttons">
                             <a href="#" class="movie-stream btn" data-player="html5">Launch HTML5 player</a>
                         </div>

--- a/dist/tpl/ShellView.html
+++ b/dist/tpl/ShellView.html
@@ -49,7 +49,7 @@
 
         <div class="sidebar-header">
             <ul class="playlist-primary-tabs">
-                <li class="playlist-primary-tab xbmc-tab active" data-pane="xbmc" title="Switch to XBMC (shared) player"><i class="fa fa-rss"></i><i class="fa fa-play"></i> XBMC</li>
+                <li class="playlist-primary-tab xbmc-tab active" data-pane="xbmc" title="Switch to Kodi (shared) player"><i class="fa fa-rss"></i><i class="fa fa-play"></i> XBMC</li>
                 <li class="playlist-primary-tab local-tab" data-pane="local" title="Switch to playback in your browser"><i class="fa fa-headphones"></i><i class="fa fa-play"></i> Local</li>
             </ul>
             <div class="playlist-actions-wrapper"></div>
@@ -135,7 +135,7 @@
                 <span class="browser-player-menu player-button dropdown-toggle" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i></span>
                 <ul class="dropdown-menu">
                     <li><a href="#" class="about-dialog">About Chorus</a></li>
-                    <li><a href="#home" class="browser-view-xbmc">XBMC Player</a></li>
+                    <li><a href="#home" class="browser-view-xbmc">Kodi Player</a></li>
                 </ul>
             </div>
         </div>

--- a/dist/tpl/TvshowView.html
+++ b/dist/tpl/TvshowView.html
@@ -130,7 +130,7 @@
                     <div class="col-1">
                         <h2>HTML5 player</h2>
                         <p>Codec support is very <a href="https://developer.mozilla.org/en-US/docs/HTML/Supported_media_formats" target="_blank">limited in the browser</a>.
-                            H.264 video generally works but only with 2 channel audio. Works best in Chrome, may crash browser and/or XBMC!</p>
+                            H.264 video generally works but only with 2 channel audio. Works best in Chrome, may crash browser and/or Kodi!</p>
                         <div class="buttons">
                             <a href="#" class="tv-stream btn" data-player="html5">Launch HTML5 player</a>
                         </div>

--- a/readme.md
+++ b/readme.md
@@ -1,94 +1,97 @@
 # Chorus
-A nice modern Web UI for your XBMC. Browse your Music, Movies or TV Shows from the comfort of your
-own web browser. You can play media via XBMC or stream it in your browser. Works best with Chrome
+A nice modern web UI for Kodi. Browse your music, movies or TV shows from the comfort of your
+own web browser. You can play media via Kodi or stream it in your browser. Works best with Chrome
 but plays well with most modern browsers.
 
 Used by the [Doghouse Media Team](http://dhmedia.com.au) to control the shared office music box
-(an old pc running XBMC with chorus, plugged into an amp and a nas)
+(an old pc running Kodi with chorus, plugged into an amp and a nas)
 
 [View the changelog](https://github.com/jez500/chorus/blob/master/dist/changelog.txt)
 
 ## Author
 Jeremy Graham
-mail@jez500.com
+[email address](mail@jez500.com)
 
-## Web
-- https://github.com/jez500/chorus
-- http://forum.xbmc.org/showthread.php?tid=183451
-- http://addons.xbmc.org/show/webinterface.chorus/
-- http://lifehacker.com/chorus-is-a-powerful-web-based-remote-control-for-xbmc-1577148641
-- http://www.makeuseof.com/tag/xbmc-users-turn-browser-remote-control-chorus/
+## Quick links
+- [Chorus Github] (https://github.com/jez500/chorus)
+- [Chorus @ Kodi forum's thread] (http://forum.kodi.tv/showthread.php?tid=183451)
+- [Chorus addon @ Kodi website] (http://addons.kodi.tv/show/webinterface.chorus/)
+
+## Chorus on the web
+- [Chorus is a powerful web based remote control for Kodi](http://lifehacker.com/chorus-is-a-powerful-web-based-remote-control-for-xbmc-1577148641)
+- [Kodi users: Turn your browser into a remote control with Chorus] (http://www.makeuseof.com/tag/xbmc-users-turn-browser-remote-control-chorus/)
 
 ## Requirements
-- XBMC v12 or 13
-- A modern web browser, this has been developed and tested in Chrome
+- Kodi v14 or newer
+- A modern web browser, it has been developed and tested in Chrome
 
 ## Installing / Updating
-You can download Chorus via the official XBMC repo
-- XBMC > Settings > Services > Web Server > Web Interface > get more
+You can download Chorus via the official Kodi repo
+- Kodi > Settings > Services > Web Server > Web Interface > get more
 - Or use the zip in this repo
 
 ## Enabling
-- XBMC > Stystem > Settings > Services > Webserver
-- tick allow access via http
-- select web interface
-- select chorus
-- you should also enable "Allow programs on other systems to control XBMC" (under "Remote Control") to get the best performance
+- NAvigate to System > Settings > Services > Webserver
+- Tick allow access via http
+- Click select web interface
+- Select Chorus
+- Enable "Allow programs on other systems to control Kodi" (under "Remote control") to get the best performance
 
 ## Using
-Add your music/movies sources and do a full music/video scan in xbmc.
-Then simply go to the address of the computer running xbmc in your browser
-(if you are using a port number add that to the url)
-eg.
+Add your music/movies sources and do a full music/video scan in Kodi.
+Then simply go to the address of the computer running Kodi in your browser
+
+There are a few ways to access web interfaces in Kodi
 - http://localhost/
 - http://localhost:8080/
-- http://192.168.0.10/
-TIP: Get your IP via XBMC > System > System Info
-
+- http://kodi.ip/
+- http://kodi-ip/:port/addons/webinterface.chorus/
+TIP: Get your IP via Kodi > System > System information
+     
 ## Performance
 If you have a large library (20000+ songs), some things get a bit sluggish, especially
-if either client or server are low power (eg. not a pc).
+if either client or server are low power (e.g. not a pc).
 
-## Target Device
+## Target device
 Chorus resizes nicely to fit on almost any screen. This is still a work in progress and some functionality is not
 yet responsive.
 
 
-## Stream music from your XBMC library into your browser ##
-As of version 0.2.0 you can use chorus to control XBMC or use it to stream the music direct to your browser!
+## Stream music from Kodi's library into your browser ##
+As of version 0.2.0 you can use chorus to control Kodi or use it to stream the music direct to your browser!
 This is still quite experimental and there are a few minor hiccups to consider:
 - [It doesn't want to work with Firefox](https://github.com/jez500/chorus/issues/5), possible an issue with HTML5 audio and mp3s. When using Chrome and even Internet Explorer 10 it works great.
 - Seeking works intermittently, I think it might be to do with how much of the song is cached, I have also heard that Gotham might fix this but have not yet tried.
-- It didn't work on my Android Media Player, this could also be caused by the XBMC version/build
+- It didn't work on my Android Media Player, this could also be caused by the Kodi version/build
 - I Haven't tested it over the internet yet, but works great over a LAN
 Otherwise it works really well!
 
 ### How to use this browser streaming ###
-In the top right there are some tabs, two of them are named XBMC and Local, this is how you toggle what player the UI
-is controlling.  In Local mode the colour scheme becomes lighter with a hint of blue, In XBMC mode the colors are
+In the top right there are some tabs, two of them are named Kodi and Local, this is how you toggle what player the UI
+is controlling.  In Local mode the colour scheme becomes lighter with a hint of blue, In Kodi mode the colors are
 the default darker scheme with a touch of orange.  When you are in a given mode, actions affect that player, so if you
-click Play on a track when in Local mode, it will play through the browser, likewise, when in XBMC mode all commands are
-sent to XBMC.  You can also add media to other playlists by clicking the menu buttons (three dots vertical) on most media items.
+click play on a track when in Local mode, it will play through the browser, likewise, when in Kodi mode all commands are
+sent to Kodi.  You can also add media to other playlists by clicking the menu buttons (three dots vertical) on most media items.
 
 
 ## Video streaming
 Video streaming via HTML5 "sort of" works, it really depends on the codec used. An embedded VLC player is also available with better codec support.
-This looks like the best we can get until XBMC supports transcoding. Look for the "stream" tab on a movie.
+This looks like the best we can get until Kodi supports transcoding. Look for the "stream" tab on a movie.
 
 
-## Supported xbmc addons
+## Supported Kodi addons
 With search integration
-- [SoundCloud AddOn](http://addons.xbmc.org/show/plugin.audio.soundcloud/)
-- [Radio AddOn](http://addons.xbmc.org/show/plugin.audio.radio_de/) - [fix for labels](https://github.com/jez500/plugin.audio.radio_de)
+- [SoundCloud add-on](http://addons.kodi.tv/show/plugin.audio.soundcloud/)
+- [Radio add-on](http://addons.kodi.tv/show/plugin.audio.radio_de/) - [fix for labels](https://github.com/jez500/plugin.audio.radio_de)
 Tested and works
-- [SHOUTcast 2](http://addons.xbmc.org/show/plugin.audio.shoutcast/) - [fix for labels](https://github.com/jez500/plugin.audio.shoutcast)
+- [SHOUTcast 2](http://addons.kodi.tv/show/plugin.audio.shoutcast/) - [fix for labels](https://github.com/jez500/plugin.audio.shoutcast)
 
 
-## Issues, Bugs and Suggestions
-Post them here https://github.com/jez500/chorus/issues - mention what version you are using
+## Issues, bugs and suggestions
+Open an issue [Click to open issue](https://github.com/jez500/chorus/issues/new) - Mention what version Chorus/Kodi you are using.
 
 ## Under the hood
-Chorus uses the following open source libraries, creds to all authors:
+Chorus uses the following open source libraries, credits to all authors:
 
 - jQuery
 - backbone
@@ -117,9 +120,9 @@ If you would like to make this project better I would appreciate any help. Send 
 A few things that are "nice to haves"
 
 - Backbone, this is my first project using backbone and I am sure I could be doing some things better (refactor)
-- Addons, Make it work with your favourite addon - I attempted google music but failed even using it via the ui
-- Mobile/Tablet App, I would love to reuse a lot of the code as an app, but dont know how
-- Browser streaming audio playback... [maybe you want it to work in firefox](https://github.com/jez500/chorus/issues/5)?
+- Addons, Make it work with your favourite addon - I attempted Google music but failed even using it via the UI
+- Mobile/Tablet App, I would love to reuse a lot of the code as an app, but don't know how
+- Browser streaming audio playback... [maybe you want it to work in Firefox](https://github.com/jez500/chorus/issues/5)?
 - Photo library, I wouldn't use it, but you might!
 
 ## Donate

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -575,7 +575,7 @@ app.Router = Backbone.Router.extend({
   /**
    * if it is a genre (string) do lookup for id then redirect
    * @TODO make... better, something other than this, problem is getMovies doesn't give you a genreid
-   * http://wiki.xbmc.org/?title=JSON-RPC_API/v6#Video.Fields.Movie
+   * http://kodi.wiki/view/JSON-RPC_API/v6#Video.Fields.Movie
    */
   movieGenre: function(name){
 
@@ -727,7 +727,7 @@ app.Router = Backbone.Router.extend({
         self.$content.html(new app.TvshowView({model: data}).render().el);
 
         // title
-        app.ui.setTitle('TVShows', { addATag: '#mytv', icon: 'desktop', subTitle: data.attributes.label });
+        app.ui.setTitle('TV Shows', { addATag: '#mytv', icon: 'desktop', subTitle: data.attributes.label });
 
         // set menu
         app.shellView.selectMenuItem('tvshow', 'sidebar');
@@ -897,7 +897,7 @@ app.Router = Backbone.Router.extend({
     $('#content').html(app.cached.xbmcView.render().$el);
 
     // set title
-    app.ui.setTitle('XBMC', {addATag: '#xbmc/home'});
+    app.ui.setTitle('Kodi', {addATag: '#xbmc/home'});
 
     // set menu
     app.shellView.selectMenuItem('xbmc', 'no-sidebar');

--- a/src/js/controllers/notifications.js
+++ b/src/js/controllers/notifications.js
@@ -1,8 +1,8 @@
 /**
- * Deal with notifications from xbmc using web sockets
- * http://wiki.xbmc.org/?title=JSON-RPC_API/v6#Notifications_2
+ * Deal with notifications from Kodi using web sockets
+ * http://kodi.wiki/view/JSON-RPC_API/v6#Notifications_2
  *
- * NOTE: for this to work You need to "Allow programs on other systems to control XBMC"
+ * NOTE: for this to work You need to "Allow programs on other systems to control Kodi"
  */
 
 
@@ -178,7 +178,7 @@ app.notifications = {
         // We set a timeout for {wait} seconds for a fallback for no input
         // this is to prevent an open dialog preventing api requests
         app.notifications.inputTimeout = setTimeout(function(){
-          var msg = '<p>About ' + wait + ' seconds ago, an input dialog opened on xbmc and it is still open! To prevent ' +
+          var msg = '<p>About ' + wait + ' seconds ago, an input dialog opened on Kodi and it is still open! To prevent ' +
             'a mainframe implosion, you should probably give me some text. I don\'t really care what it is at this point, ' +
             'why not be creative? Do you have a <a href="http://goo.gl/PGE7wg" target="_blank">word of the day</a>? I won\'t tell...</p>';
           app.xbmcController.inputRequestedDialog(msg);
@@ -195,7 +195,7 @@ app.notifications = {
 
       // xbmc shutdown
       case 'System.OnQuit':
-        app.notification('XBMC has quit');
+        app.notification('Kodi has quit');
         break;
     }
 

--- a/src/js/controllers/playerState.js
+++ b/src/js/controllers/playerState.js
@@ -102,12 +102,12 @@ app.playerState = {
       // 10 mins with no connection - increase throttle
       if(app.counts['503total'] > 30){
         throttle = 6;
-        app.notification('No connection to XBMC for 10mins! I\'ll check if it\'s there less often now ');
+        app.notification('No connection to Kodi for 10mins! I\'ll check if it\'s there less often now ');
       }
       // 30 mins with no connection - increase throttle ((20min * 60sec) / (6throttle * 5interval)) + 30previousThrottle = 40
       if(app.counts['503total'] > 70){
         throttle = 12;
-        app.notification('No connection to XBMC for 30mins! I\'m pretty sure it has gone walkabout');
+        app.notification('No connection to Kodi for 30mins! I\'m pretty sure it has gone walkabout');
       }
 
       // reset count to 0 if at throttle
@@ -121,7 +121,7 @@ app.playerState = {
         app.counts[503]++;
         app.state = 'notconnected';
         if(app.counts[503] == 3){
-          app.notification('Lost connection to XBMC');
+          app.notification('Lost connection to Kodi');
         }
         return;
       } else {

--- a/src/js/controllers/xbmc.js
+++ b/src/js/controllers/xbmc.js
@@ -45,7 +45,7 @@ app.xbmcController.command = function(command, options, callback, errorCallback)
 
 /**
  * Call an input command
- * http://wiki.xbmc.org/?title=JSON-RPC_API/v6#Input
+ * http://kodi.wiki/view/JSON-RPC_API/v6#Input
  *
  * @param type
  * @param callback
@@ -237,7 +237,7 @@ app.xbmcController.entityLoadMultiple = function(type, items, callback){
 
 /**
  * Input requested from xbmc
- * Opens prompt dialog and sends the user inputted text to xbmc via Input.SendText
+ * Opens prompt dialog and sends the user input text to xbmc via Input.SendText
  *
  * @param msg
  */

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -940,7 +940,7 @@ $(document).ready(function(){
           key: 'album',
           omitwrapper: true,
           items: [
-            {url: '#', class: 'album-add-xbmc', title: 'Add to XBMC', callback: function(){
+            {url: '#', class: 'album-add-xbmc', title: 'Add to Kodi', callback: function(){
               app.playlists.playlistAddItems('xbmc', 'append', 'album', model.albumid);
             }},
             {url: '#', class: 'album-add-local', title: 'Play in browser', callback: function(){
@@ -960,7 +960,7 @@ $(document).ready(function(){
           key: 'artist',
           omitwrapper: true,
           items: [
-            {url: '#', class: 'artist-add-xbmc', title: 'Add to XBMC', callback: function(){
+            {url: '#', class: 'artist-add-xbmc', title: 'Add to Kodi', callback: function(){
               app.playlists.playlistAddItems('xbmc', 'append', 'artist', model.artistid);
             }},
             {url: '#', class: 'artist-add-local', title: 'Play in browser', callback: function(){
@@ -997,7 +997,7 @@ $(document).ready(function(){
             {url: '#', class: 'refresh-playlist', title: 'Refresh Playlist'},
             {url: '#', class: 'party-mode', title: 'Party Mode <i class="fa fa-check"></i>'},
             {class: 'dropdown-header', title: 'Audio'},
-            {url: '#', class: 'save-playlist', title: 'Save XBMC Playlist'},
+            {url: '#', class: 'save-playlist', title: 'Save Kodi Playlist'},
             {url: '#', class: 'new-custom-playlist', title: 'New Browser Playlist'}
           ]
         };

--- a/src/js/views/remote.js
+++ b/src/js/views/remote.js
@@ -71,7 +71,7 @@ app.RemoteView = Backbone.View.extend({
       key: 'powerDown',
       omitwrapper: true,
       items: [
-        {url: '#', class: 'xbmc-quit', title: 'Quit XBMC', callback: function(){
+        {url: '#', class: 'xbmc-quit', title: 'Quit Kodi', callback: function(){
           // Quit xbmc
           app.xbmcController.command('Application.Quit');
         }},


### PR DESCRIPTION
@jez500 

This was started purely to change the visible (not code entries) of XBMC/xbmc to Kodi 
Probably missed a few and some wast quite sure e.g. https://github.com/jez500/chorus/blob/94e575ee5eb2bbaa607387a7c94ec1c95fe6d0ec/src/js/helpers/settings.js#L17 I think these are appmessenger portions that depend on Kodi so best not touch them.

It shouldn't break anything as the changes are indeed cosmetic for the ones which were done.

Then I stumbled on the readme and my OCD kicked in. I tried to contain myself best as possible so that was the result of that altercation 
So while at it updated the links to kodi wiki and kodi tv where applicable.

You can review the Readme by [clicking here](https://github.com/uNiversaI/chorus/blob/master/readme.md)
Ill be happy to adjust anything to suit any feedback