### PR TITLE
Fix dialog repeatedly binding keypress event

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -664,6 +664,9 @@ $(document).ready(function(){
     $dialog.html(content);
     $dialog.dialog( "option", options );
 
+    // remove old event bindings
+    $dialog.unbind();
+
     //fix scrollTo issue with dialog
     $dialog.bind( "dialogopen", function(event, ui) {
       $('.ui-widget-overlay, .ui-dialog').css('position', 'fixed');

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -639,30 +639,7 @@ $(document).ready(function(){
 
     settings = jQuery.extend(settings, options);
 
-    var $dialog = $( app.helpers.getSelector('dialog') );
-
-    $dialog.dialog( settings );
-
-    // bind to enter
-    $dialog.keypress(function(e) {
-      if (e.keyCode == $.ui.keyCode.ENTER) {
-        // look for a button with class "bind-enter" first, fallback to OK btn, fallback to none.
-        var $parent = $(this).parent(),
-          $enterButton = $parent.find('.bind-enter'),
-          $btn = ($enterButton.length === 0 ? $parent.find('.ui-dialog-buttonpane button:first') : $enterButton);
-        // if button pane exists
-        if($parent.find('.ui-dialog-buttonpane button').length > 0){
-          console.log("clicking");
-          $btn.trigger("click");
-        }
-      }
-    });
-
-    //fix scrollTo issue with dialog
-    $dialog.bind( "dialogopen", function(event, ui) {
-      $('.ui-widget-overlay, .ui-dialog').css('position', 'fixed');
-      $('.dialog-menu a:last').addClass('last');
-    });
+    $( app.helpers.getSelector('dialog') ).dialog( settings );
 
   };
 
@@ -686,6 +663,26 @@ $(document).ready(function(){
     //set content and options
     $dialog.html(content);
     $dialog.dialog( "option", options );
+
+    //fix scrollTo issue with dialog
+    $dialog.bind( "dialogopen", function(event, ui) {
+      $('.ui-widget-overlay, .ui-dialog').css('position', 'fixed');
+      $('.dialog-menu a:last').addClass('last');
+
+      // bind to enter
+      $dialog.keypress(function(e) {
+        if (e.keyCode == $.ui.keyCode.ENTER) {
+          // look for a button with class "bind-enter" first, fallback to OK btn, fallback to none.
+          var $parent = $(this).parent(),
+            $enterButton = $parent.find('.bind-enter'),
+            $btn = ($enterButton.length === 0 ? $parent.find('.ui-dialog-buttonpane button:first') : $enterButton);
+          // if button pane exists
+          if($parent.find('.ui-dialog-buttonpane button').length > 0){
+            $btn.trigger("click");
+          }
+        }
+      });
+    });
 
     //open
     $dialog.dialog( "open" );

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -639,7 +639,30 @@ $(document).ready(function(){
 
     settings = jQuery.extend(settings, options);
 
-    $( app.helpers.getSelector('dialog') ).dialog( settings );
+    var $dialog = $( app.helpers.getSelector('dialog') );
+
+    $dialog.dialog( settings );
+
+    // bind to enter
+    $dialog.keypress(function(e) {
+      if (e.keyCode == $.ui.keyCode.ENTER) {
+        // look for a button with class "bind-enter" first, fallback to OK btn, fallback to none.
+        var $parent = $(this).parent(),
+          $enterButton = $parent.find('.bind-enter'),
+          $btn = ($enterButton.length === 0 ? $parent.find('.ui-dialog-buttonpane button:first') : $enterButton);
+        // if button pane exists
+        if($parent.find('.ui-dialog-buttonpane button').length > 0){
+          console.log("clicking");
+          $btn.trigger("click");
+        }
+      }
+    });
+
+    //fix scrollTo issue with dialog
+    $dialog.bind( "dialogopen", function(event, ui) {
+      $('.ui-widget-overlay, .ui-dialog').css('position', 'fixed');
+      $('.dialog-menu a:last').addClass('last');
+    });
 
   };
 
@@ -663,26 +686,6 @@ $(document).ready(function(){
     //set content and options
     $dialog.html(content);
     $dialog.dialog( "option", options );
-
-    //fix scrollTo issue with dialog
-    $dialog.bind( "dialogopen", function(event, ui) {
-      $('.ui-widget-overlay, .ui-dialog').css('position', 'fixed');
-      $('.dialog-menu a:last').addClass('last');
-
-      // bind to enter
-      $dialog.keypress(function(e) {
-        if (e.keyCode == $.ui.keyCode.ENTER) {
-          // look for a button with class "bind-enter" first, fallback to OK btn, fallback to none.
-          var $parent = $(this).parent(),
-            $enterButton = $parent.find('.bind-enter'),
-            $btn = ($enterButton.length === 0 ? $parent.find('.ui-dialog-buttonpane button:first') : $enterButton);
-          // if button pane exists
-          if($parent.find('.ui-dialog-buttonpane button').length > 0){
-            $btn.trigger("click");
-          }
-        }
-      });
-    });
 
     //open
     $dialog.dialog( "open" );


### PR DESCRIPTION
`app.helpers.dialog` binds another dialogopen event every time a dialog is opened. Each of those dialogopens then binds another keypress function each time the dialog is opened. The exponential growth of keypress functions is problematic for prompts, where the resulting button click triggers some action. :o

Moves the binding to `app.helpers.dialogInit` where they should only bind once.