### PR TITLE
Play Folder Fix

### DIFF
--- a/dist/chorus.js
+++ b/dist/chorus.js
@@ -25187,6 +25187,10 @@ app.FileView = Backbone.View.extend({
     if(file.type == "directory"){
       ret.key = file.type;
     }
+    
+    if(file.filetype && file.filetype == "directory"){
+        ret.key = file.filetype;
+    }
 
     return ret;
   },


### PR DESCRIPTION
File.type is unknown for an directory link/id but the attribute file.filetype says directory, so i did this tiny addon to fix the issue #59 "Play Folder".
Don't know if filetype is always be set, so i did a check at the beginning.