### PR TITLE
Added a llink to the forum thread

### DIFF
--- a/src/addon.xml
+++ b/src/addon.xml
@@ -15,5 +15,8 @@
     <description lang="en">Only use this version for dev, see dist folder for production ready</description>
     <platform>all</platform>
     <language>en</language>
+    <license></license>
+    <forum>http://forum.kodi.tv/showthread.php?tid=183451</forum>
+    <source>https://github.com/jez500/chorus</source>
   </extension>
 </addon>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.

Didn't manage to find only the license.