### PR TITLE
Fix song title not to be clipped off in the player.

### DIFF
--- a/src/theme/sass/components/_player.scss
+++ b/src/theme/sass/components/_player.scss
@@ -198,7 +198,6 @@
     display: block;
     margin-top: 20px;
     height: 20px;
-    overflow: hidden;
     white-space: nowrap;
     margin-right: 130px;
     @include breakpoint($width-tablet){


### PR DESCRIPTION
This should fix #65.